### PR TITLE
Support functional-style error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ fn build_params(oauth_params: LinkedList<Parameter>, additional_params: LinkedLi
   params
 }
 
-pub fn request(keys: &Keys, method: Method, end_point: &str, argument_params: LinkedList<Parameter>) -> String {
+pub fn request(keys: &Keys, method: Method, end_point: &str, argument_params: LinkedList<Parameter>) -> Result<String> {
 
   let mut oauth_params: LinkedList<Parameter> = gen_oauth_params(keys);
   let mut params: LinkedList<Parameter> = build_params(oauth_params.clone(), argument_params.clone());
@@ -208,44 +208,39 @@ pub fn request(keys: &Keys, method: Method, end_point: &str, argument_params: Li
   let mut easy = Easy::new();
 
   let mut list = List::new();
-  list.append(&authorize).unwrap();
-  easy.http_headers(list).unwrap();
+  try!(list.append(&authorize));
+  try!(easy.http_headers(list));
 
   match method {
     Method::Get => {
-      easy.url(&format!("{}?{}", url, path)).unwrap();
+      try!(easy.url(&format!("{}?{}", url, path)));
 
       let mut transfer = easy.transfer();
 
-      transfer.write_function(|data| {
-          dst.extend_from_slice(data);
-          Ok(data.len())
-        })
-        .unwrap();
+      try!(transfer.write_function(|data| {
+        dst.extend_from_slice(data);
+        Ok(data.len())
+      }));
 
-      transfer.perform().unwrap();
+      try!(transfer.perform());
     }
     Method::Post => {
-      easy.post(true).unwrap();
-      easy.post_field_size(path.len() as u64).unwrap();
-      easy.url(&url).unwrap();
+      try!(easy.post(true));
+      try!(easy.post_field_size(path.len() as u64));
+      try!(easy.url(&url));
 
       let mut transfer = easy.transfer();
 
-      transfer.read_function(|buf| Ok(path.as_bytes().read(buf).unwrap_or(0))).unwrap();
+      try!(transfer.read_function(|buf| Ok(path.as_bytes().read(buf).unwrap_or(0))));
 
-      transfer.write_function(|data| {
-          dst.extend_from_slice(data);
-          Ok(data.len())
-        })
-        .unwrap();
+      try!(transfer.write_function(|data| {
+        dst.extend_from_slice(data);
+        Ok(data.len())
+      }));
 
-      transfer.perform().unwrap();
+      try!(transfer.perform());
     }
   }
 
-
-  let ret = String::from_utf8(dst).expect("failed to convert u8(dst) to String(ret)");
-
-  ret
+  String::from_utf8(dst).map_err(|e| e.into())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,41 @@ use std::collections::LinkedList;
 use curl::easy::{Easy, List};
 use std::io::Read;
 
+#[derive(Debug)]
+pub enum Error {
+  Curl(curl::Error),
+  FromUtf8(std::string::FromUtf8Error)
+}
+
+impl std::fmt::Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    match *self {
+      Error::Curl(ref err) => write!(f, "Error::Curl: {}", err),
+      Error::FromUtf8(ref err) => write!(f, "Error::FromUtf8: {}", err),
+    }
+  }
+}
+
+impl std::error::Error for Error {
+  fn description(&self) -> &str {
+    match *self {
+      Error::Curl(ref err) => err.description(),
+      Error::FromUtf8(ref err) => err.description(),
+    }
+  }
+}
+
+impl From<curl::Error> for Error {
+  fn from(err: curl::Error) -> Error { Error::Curl(err) }
+}
+
+impl From<std::string::FromUtf8Error> for Error {
+  fn from(err: std::string::FromUtf8Error) -> Error { Error::FromUtf8(err) }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+
 fn url_encode(s: &str) -> String {
   let mut en = String::new();
 

--- a/t4rs_test/src/main.rs
+++ b/t4rs_test/src/main.rs
@@ -12,12 +12,12 @@ fn main() {
   );
 
   let params: LinkedList<Parameter> = LinkedList::new();
-  println!("{}", request(&keys, Method::Get, "account/verify_credentials.json", params));
+  println!("{}", request(&keys, Method::Get, "account/verify_credentials.json", params).unwrap());
 
   let mut params2: LinkedList<Parameter> = LinkedList::new();
 
   params2.push_back(Parameter::new("status", "Hello World From Rust!!!"));
 
-  println!("result -> {}", request(&keys, Method::Post, "/statuses/update.json", params2));
+  println!("result -> {}", request(&keys, Method::Post, "/statuses/update.json", params2).unwrap());
 }
 


### PR DESCRIPTION
ライブラリの利用側で柔軟なエラー処理ができるよう，`request()` の戻り値を `Result<>` に変更しました．
